### PR TITLE
Fix Mion/Shion

### DIFF
--- a/Update/wata_007.txt
+++ b/Update/wata_007.txt
@@ -2300,7 +2300,7 @@
 
 //　あぁ、それなら先日、エンジェルモートで詩音に...いや魅音に教えてもらったんで知ってる￥
 	OutputLine(NULL, "　あぁ、それなら先日、エンジェルモートで詩音に…いや魅音に教えてもらったんで知ってる。",
-		   NULL, "Oh, yeah. The other day, at Angel Mort, Shion—or Mion, rather—told me all about it.", Line_Normal);
+		   NULL, "Oh, yeah. The other day, at Angel Mort, Mion—or Shion, rather—told me all about it.", Line_Normal);
 	ClearMessage();
 
 //「確か、雛見沢が丸ごと水没する巨大なダムの計画が発表されたって言うんですよね。＠


### PR DESCRIPTION
Make sure that this change is correct before merging please.

I don't recall Mion ever going to Angel Mort, it was Shion all the time and it was also Shion who told Keichi about the dam project - right?

Can you check the japanese version as well?
