### PR TITLE
misc translation fixes

### DIFF
--- a/Update/wata_010.txt
+++ b/Update/wata_010.txt
@@ -1739,7 +1739,7 @@ void main()
 //　......こういうのが好きな子と日直を組めれば、勝手にやってくれるからとても気楽なのだが￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　……こういうのが好きな子と日直を組めれば、勝手にやってくれるからとても気楽なのだが。",
-		   NULL, "......For this, if one was placed on day duty with someone one liked, they'd do it all for you, so it'd be cake.", Line_Normal);
+		   NULL, "......If you were placed on day duty with someone who liked this sort of thing, they'd do it all for you, so it'd be cake.", Line_Normal);
 	ClearMessage();
 
 //「悪態をついても仕方ないな＠...諦めて、仕事を始めるか。＠

--- a/Update/wata_010_04.txt
+++ b/Update/wata_010_04.txt
@@ -2685,7 +2685,7 @@ void main()
 //　もっとも、この隙に逃げ出せるわけではないのだが...￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　もっとも、この隙に逃げ出せるわけではないのだが…。",
-		   NULL, "Of course, it's not like I could escape through this opening...", Line_Normal);
+		   NULL, "Of course, it's not like I could use this opening to escape...", Line_Normal);
 	ClearMessage();
 
 //「.........そうですねぇ＠ハイハイ＠...では戻りましょう＠ハイハイ＠ハイハイ。＠

--- a/Update/wata_010_04.txt
+++ b/Update/wata_010_04.txt
@@ -212,7 +212,7 @@ void main()
 //　...駆け寄り、介抱するように背中を撫でてくれた￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　…駆け寄り、介抱するように背中を撫でてくれた。",
-		   NULL, "...She ran over and rubbed my back, like she was trying to make me feel better.", Line_Normal);
+		   NULL, "...She ran over and rubbed my back, to make me feel better.", Line_Normal);
 	ClearMessage();
 
 //「............俺が、!w1000......全部、悪いんだ＠......俺のせいで...＠...俺のせいで...。＠

--- a/Update/wata_011.txt
+++ b/Update/wata_011.txt
@@ -697,9 +697,9 @@ void main()
 		   NULL, "\"All rise!\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
-//　こんな狂った日常になってしまったからこそ、学校という空間だけでもいつのも日常を保とうという気持ちには、......今だけは賛成だった￥
+//　こんな狂った日常になってしまったからこそ、学校という空間だけでもいつもの日常を保とうという気持ちには、......今だけは賛成だった￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
-	OutputLine(NULL, "　こんな狂った日常になってしまったからこそ、学校という空間だけでもいつのも日常を保とうという気持ちには、……今だけは賛成だった。",
+	OutputLine(NULL, "　こんな狂った日常になってしまったからこそ、学校という空間だけでもいつもの日常を保とうという気持ちには、……今だけは賛成だった。",
 		   NULL, "That feeling of wanting to maintain an everyday atmosphere, even if only in school, precisely because our lives had been messed up... was something that I agreed with at this point.", Line_Normal);
 	ClearMessage();
 

--- a/Update/wata_011_02.txt
+++ b/Update/wata_011_02.txt
@@ -2040,7 +2040,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s02/11/130700310", 256, TRUE);
 	OutputLine(NULL, "「学校は平気で休むし、それを自宅に知らせても取り合ってもらえないから、学校もいちいち電話しない。",
-		   NULL, "\"She took breaks from class like it was nothing, and her family wouldn't listen when I told them, so I didn't bother calling the school in the end. ", GetGlobalFlag(GLinemodeSp));
+		   NULL, "\"She took breaks from class like it was nothing, and her family wouldn't listen when the school told them, so they mostly don't bother calling anymore.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s02/11/130700311", 256, TRUE);
 	OutputLine(NULL, "…そんなこんなで、彼女が失踪したことに気付くのにだいぶ時間がかかったんですよ。」",

--- a/Update/wata_012.txt
+++ b/Update/wata_012.txt
@@ -1653,14 +1653,14 @@ void main()
 		   NULL, "\"Roger that.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 19, "ps3/s02/19/133100009", 256, TRUE);
 	OutputLine(NULL, "３号、７号は先ほど応援が到着、帰投しました。",
-		   NULL, " Cars three and seven just arrived for support, and we've returned to base.", Line_WaitForInput);
+		   NULL, " The relief for three and seven just arrived, and they've returned to base.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 19, "ps3/s02/19/133100010", 256, TRUE);
 	OutputLine(NULL, "…あと、課長が大石さん探してるみたいっす。",
-		   NULL, " ...Also, I think the division chief is looking for you, Ooishi-san. ", GetGlobalFlag(GLinemodeSp));
+		   NULL, " ...Also, it looks like the division chief is looking for you, Ooishi-san. ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#8f6d8f>熊谷</color>", NULL, "<color=#8f6d8f>Kumagai</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 19, "ps3/s02/19/133100011", 256, TRUE);
 	OutputLine(NULL, "私のとこにも、連絡がつき次第ってさっきから何回もうるさいんすけど…どうします？」",
-		   NULL, "He keeps annoying me, too, even though I keep telling him I'm trying to get in touch with you... What should I do?\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "He keeps bugging me, too, to tell him as soon as I get in touch with you... What do you want me to do?\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/wata_012_02.txt
+++ b/Update/wata_012_02.txt
@@ -1197,7 +1197,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#5ec69a>魅音</color>", NULL, "<color=#5ec69a>Mion</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 3, "ps3/s02/03/130300286", 256, TRUE);
 	OutputLine(NULL, "「お茶請けはゴマ煎でいい？",
-		   NULL, "\"Do you want sesame seeds on your rice?", Line_WaitForInput);
+		   NULL, "\"Do you want some sesame senbei to go with that?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s02/03/130300287", 256, TRUE);
 	OutputLine(NULL, "　ようかんとか、気の利いたものがなくて申し訳ないね。」",
 		   NULL, " Sorry we don't have much in the way of bean paste or other good stuff.\"", GetGlobalFlag(GLinemodeSp));
@@ -5282,7 +5282,7 @@ void main()
 	OutputLine(NULL, "　魅音が、…重い、抗うことのできない因習に飲まれ、",
 		   NULL, "Mion had been engulfed... by heavy, unopposable tradition...", Line_WaitForInput);
 	OutputLine(NULL, "…仲間をその手にかけなければならなくしてしまったのは………他でもない、俺自身なのだ。",
-		   NULL, " ...Right now, the duty of handling this had fallen...... to me, and me alone.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " ...The one who had forced her to kill her friends with her own hands...... That was me, and me alone.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping); }
 
 //　むしろ魅音は、......追い込んだ俺を責めてもいいくらいなのだ￥
@@ -5536,14 +5536,14 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f0953d>レナ</color>", NULL, "<color=#f0953d>Rena</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 2, "ps3/s02/02/130200581", 256, TRUE);
 	OutputLine(NULL, "「…………魅ぃちゃんが短気を起こさないように、…見張ってね。」",
-		   NULL, "\".........Watch out... so that you don't make her lose her temper, okay?\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "\".........Watch out... that she doesn't do anything rash, okay?\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 
 //　魅音は司法なんかに身を委ねずに、...自らの手で幕を下ろすかもしれない＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　魅音は司法なんかに身を委ねずに、…自らの手で幕を下ろすかもしれない。",
-		   NULL, "Mion might not surrender herself to justice... so I might have to put an end to it myself.", GetGlobalFlag(GLinemodeSp));
+		   NULL, "Mion might not surrender herself to justice... but instead choose to put an end to things herself.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/wata_012_03.txt
+++ b/Update/wata_012_03.txt
@@ -588,7 +588,7 @@ void main()
 //　魅音は自分の身を司法に委ねず...自ら幕を引くつもりかもしれない￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　魅音は自分の身を司法に委ねず…自ら幕を引くつもりかもしれない。",
-		   NULL, "Mion might not surrender herself to justice... but instead choose to put an end to things herself.", Line_Normal);
+		   NULL, "Mion might not surrender herself to justice... but choose to put an end to things herself.", Line_Normal);
 	ClearMessage();
 
 //　...魅音をひとりにしてはいけない＠

--- a/Update/wata_tips_03.txt
+++ b/Update/wata_tips_03.txt
@@ -215,7 +215,7 @@ void main()
 	OutputLine(NULL, "　…ボックスシートでバッグ床置きはやはり警戒されたかなー…。",
 		   NULL, "...Maybe they were wary, since I sat in a booth and left my bag on the floor...", Line_WaitForInput);
 	OutputLine(NULL, "もうボストンバッグに隠しカメラは化石技かも…。",
-		   NULL, " My camera was already hidden in my travel bag, and might fossilize in there...", GetGlobalFlag(GLinemodeSp));
+		   NULL, "Perhaps the hidden camera in a bag trick is already old hat...", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/wata_tips_24.txt
+++ b/Update/wata_tips_24.txt
@@ -304,7 +304,7 @@ void main()
 	OutputLine(NULL, "「ゲストのエスコート役は私がやります。",
 		   NULL, "\"I'll handle escorting our guest.", Line_Continue);
 	OutputLine(NULL, "きっと会場へ連れて行きますので皆さん、気長に待ってください。」",
-		   NULL, " I'll probably take 'em to the venue, so wait patiently, everyone.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "You can be sure I'll bring 'em to the venue, so wait patiently, everyone.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/zwata_010_02_vm00_n01.txt
+++ b/Update/zwata_010_02_vm00_n01.txt
@@ -30,7 +30,7 @@ void dialog002()
 		   NULL, "\"...Now she's pretty laid-back, so it might be hard to imagine.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 6, "ps2/06/130600371", 540, TRUE);
 	OutputLine(NULL, "器物破損から脅迫、暴行まで一通りこなして、何度も補導されたんですよ。",
-		   NULL, " They put her in charge of everything, from property damage to threats and even acts of violence. ", GetGlobalFlag(GLinemodeSp));
+		   NULL, "She did everything, from property damage to threats and even acts of violence, and she was picked up for it countless times.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#5ec69a>詩音</color>", NULL, "<color=#5ec69a>Shion</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 6, "ps3/s02/06/130600372", 256, TRUE);
 	OutputLine(NULL, "…子供ですから、すぐに釈放してもらえたみたいですけどね。",


### PR DESCRIPTION
This is my first time contributing to a git/GitHub repository, please bear with me and consider this a test run ... Feedback appreciated.

I have more, and I would be fine keeping an eye out going forward, but first I want to make sure I'm doing it right.

- The first one is a は・が error
- お茶請け【おちゃうけ】 is a something to eat served with tea, like biscuits, cake, confectionery, so 煎 is probably short for 煎餅【せんべい】, as those are a traditional choice. In any case, rice doesn't make any sense. I suspect a mix-up with お茶漬【おちゃづけ】, which is a dish of rice soaked in tea.
- 手にかけける as a phrase can mean 'kill personally'.
- 短気を起こさない is broader than 'not lose one's temper', and from context it's clearly a euphemism for 'not kill oneself' here.
- The next line occurs twice with minimal variation, the second time the translation was correct, so I synced them up.
- The "fossilisation" in the last item is not meant literally ...