### PR TITLE
Cast review fixes

### DIFF
--- a/Update/omake_02.txt
+++ b/Update/omake_02.txt
@@ -676,8 +676,8 @@ void main()
 
 //「意見も何も...、今回のシナリオで解明編なのではありませんことー＠　犯人は魅音さん＠　諸悪の根源はぜ～んぶ園崎家＠　それで決着でございませんの。＠
 	//VoiceMatching
-	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("zomake_02_vm0x_n01","dialog000");}
-	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("zomake_02_vm00_n01","dialog000");}
+	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("zomake_02_vm0x_n01","dialog001");}
+	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("zomake_02_vm00_n01","dialog001");}
 	//VoiceMatchingEnd
 
 	ModPlayVoiceLS(4, 4, "ps3/s20/04/440400180", 256, TRUE);
@@ -1853,15 +1853,17 @@ void main()
 	ModPlayVoiceLS(4, 9, "ps3/s20/09/440900117", 256, TRUE);
 	OutputLine(NULL, "圭一くん以外の人の死には何かしら理由が見つけられるんだけど、…圭一くんだけなぜかいつも曖昧。",
 		   NULL, " We can find some kind of reason for everyone but Keiichi-kun to die... but for some reason, Keiichi-kun's death is always vague.", Line_WaitForInput);
-	ModPlayVoiceLS(4, 9, "ps3/s20/09/440900118", 256, TRUE);
-	OutputLine(NULL, "…「鬼隠し」でも「たらいまわし」でも、そして今回の「綿流し」でも。",
-		   NULL, " ...Last time in Onikakushi and Taraimawashi. And now in Watanagashi. ", GetGlobalFlag(GLinemodeSp));
+		   
+	//VoiceMatching
+	if(GetGlobalFlag(GCensor) >= 3){ModCallScriptSection("zomake_02_vm0x_n01","dialog002");}
+	if(GetGlobalFlag(GCensor) <= 2){ModCallScriptSection("zomake_02_vm00_n01","dialog002");}
+	//VoiceMatchingEnd
+	
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f6d9a8>鷹野</color>", NULL, "<color=#f6d9a8>Takano</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 9, "ps3/s20/09/440900119", 256, TRUE);
 	OutputLine(NULL, "祭具殿に踏み入るのとは無関係に狙われてる。」",
 		   NULL, "He was being targeted regardless of whether he went into the ritual storehouse.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
-
 
 
 //＜鷹野

--- a/Update/omake_02.txt
+++ b/Update/omake_02.txt
@@ -1510,7 +1510,7 @@ void main()
 		   NULL, "\"That's right.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300348", 256, TRUE);
 	OutputLine(NULL, "「鬼隠し」のシナリオで名前だけ登場した「監督」ってのがかなり怪しいかな！」",
-		   NULL, " The manager who only appeared by name in the last story is pretty suspicious, if you ask me!\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, " The director who only appeared by name in the last story is pretty suspicious, if you ask me!\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/zomake_02_vm00_n01.txt
+++ b/Update/zomake_02_vm00_n01.txt
@@ -4,8 +4,19 @@ void main()
 
 void dialog000()
 {
+}
+
+void dialog001()
+{
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#fcdb77>沙都子</color>", NULL, "<color=#fcdb77>Satoko</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 4, "ps3/s20/04/440400179", 256, TRUE);
 	OutputLine(NULL, "「意見も何も…、今回のシナリオで解明編なのではありませんことー？",
 		   NULL, "\"An honest opinion... was the story this time not an answer chapter?", Line_WaitForInput);
+}
+
+void dialog002()
+{
+	ModPlayVoiceLS(4, 9, "ps3/s20/09/440900118", 256, TRUE);
+	OutputLine(NULL, "…前回と今回。",
+		   NULL, " ...Both this time and last time. ", GetGlobalFlag(GLinemodeSp));
 }

--- a/Update/zomake_02_vm0x_n01.txt
+++ b/Update/zomake_02_vm0x_n01.txt
@@ -4,8 +4,19 @@ void main()
 
 void dialog000()
 {
+}
+
+void dialog001()
+{
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#fcdb77>沙都子</color>", NULL, "<color=#fcdb77>Satoko</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 4, "ps3/s20/04/440400179", 256, TRUE);
 	OutputLine(NULL, "「意見も何も…、今回のシナリオで謎は全て解けたのではありませんことー？",
 		   NULL, "\"What is there to say?... weren't all of the mysteries solved in this chapter?", Line_WaitForInput);
+}
+
+void dialog002()
+{	   
+	ModPlayVoiceLS(4, 9, "ps3/s20/09/440900118", 256, TRUE);
+	OutputLine(NULL, "…「鬼隠し」でも「たらいまわし」でも、そして今回の「綿流し」でも。",
+		   NULL, " ...Last time in Onikakushi and Taraimawashi. And now in Watanagashi. ", GetGlobalFlag(GLinemodeSp));	
 }

--- a/Update/zwata_001_vm00_n01.txt
+++ b/Update/zwata_001_vm00_n01.txt
@@ -73,7 +73,7 @@ void dialog005()
 {
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 
-	OutputLine(NULL, "　百億兆者ゲーム。",
+	OutputLine(NULL, "　百万長者ゲーム。",
 		   NULL, "It was a game called \"Billionaire.\"", GetGlobalFlag(GLinemodeSp));
 
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }

--- a/Update/zwata_001_vm00_n01.txt
+++ b/Update/zwata_001_vm00_n01.txt
@@ -73,7 +73,7 @@ void dialog005()
 {
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 
-	OutputLine(NULL, "　百万長者ゲーム。",
+	OutputLine(NULL, "　百億兆者ゲーム。",
 		   NULL, "It was a game called \"Billionaire.\"", GetGlobalFlag(GLinemodeSp));
 
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }


### PR DESCRIPTION
I found a couple issues when playing through the All-Cast Review Session today:

1. A single line acts like the player has read Taraimawashi, which is very unlikely to be true unless they are actually playing on a console. This is also inconsistent with other lines that talk about Onikakushi as "the previous scenario". To counter this I've readded the original PC line on the default voice matching level and below. (I opened issue #102 for this, but found it was easier to implement myself than expected so I've gone ahead with that here.) 
2. Currently there's a line referring to a "manager" character from Onikakushi. This [was eventually changed to "director"](https://github.com/07th-mod/onikakushi/commit/270946caf41bd5ef8143bf690ee9b103300e9e18), so I've now made the same change to be consistent here. (Though I've not played further than this yet - I guess I may be risking inconsistency with the later games.)

