### PR TITLE
Update wata_010.txt to fix chronological translation error

### DIFF
--- a/Update/wata_010.txt
+++ b/Update/wata_010.txt
@@ -2238,7 +2238,7 @@ void main()
 //　あの晩の出来事は...誰にも知られていないどころか......、!w1000誰もが知っている...？￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "　あの晩の出来事は…誰にも知られていないどころか……、",
-		   NULL, "We thought nobody knew... about what we did last night, but...", Line_ContinueAfterTyping);
+		   NULL, "We thought nobody knew... about what we did that night, but...", Line_ContinueAfterTyping);
 
 	SetValidityOfInput( FALSE );
 	Wait( 1000 );


### PR DESCRIPTION
In the context of the scene where I've changed a line, Keiichi is asked about what he did the night of the Watanagashi festival. In his thoughts, he says "We thought nobody knew... about what we did last night, but..." The issue is that the Watanagashi festival was not last night, but the night prior; day 8, not day 10. I've changed the word "last" to "that". "We thought nobody knew... about what we did that night, but..."